### PR TITLE
chore(.gitignore): improve .gitignore filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,9 @@
-*.class
-*.log
-*.ctxt
-.mtj.tmp/
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-.env*
-.build/
-build/
-.idea/
-*.iml
-
+# ignore all files and directories by default
+/*
+# keep only allowed files
+!/src
+!/docs
+!/.gitignore
+!/LICENSE
+!/Makefile
+!/README.md


### PR DESCRIPTION
Improved project's filtering by updating the .gitignore file to exclude all files by default, and allow only the selected ones. This approach will ensure that the accidental creted files won't be pushed to the remote.