### PR TITLE
build(Makefile): fix quoting for CMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 
 # execute the compiled java bytecode with potimization applied
 execute: __execute__fail__no_build_dir := Build directory doesn't exist: $(FG_YELLOW)$(BUILD_DIR)/$(CA)
-execute: __execute__java_run_command := java -cp '$(BUILD_DIR)' -XX:+TieredCompilation -XX:TieredStopAtLevel=4 $(ENTRY_POINT_BASE_CLASS)
+execute: __execute__java_run_command := java -cp $(BUILD_DIR) -XX:+TieredCompilation -XX:TieredStopAtLevel=4 $(ENTRY_POINT_BASE_CLASS)
 execute:
 ifeq ($(verbose), true)
 	$(call ECHO,[Java] Executing...)


### PR DESCRIPTION
CMD by default treats quotes `'` and `"` as literal strings, making it harder to specify arguments with possible escape sequences. If `bitsadmin` command doesn't work when downloading the JUnit .jar file, pass the `method=2`/`method=powershell` or `method=3`/`method=curl` (if curl is installed) parameter to the `make test` command to use a different method to initially download the JUnit .jar file. Subsequent invocations of `make test` won't download the .jar file again. It is needed only one time when downloading the dependency.