### PR TITLE
build(Makefile): modify the default download method of dependencies on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: "Java CI"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: "Java: Tests"
+    # includes all needed software needed for tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone commit
+        run: |
+          git init
+          git remote add origin https://github.com/${{ github.repository }}.git
+          git fetch --depth=1 origin ${{ github.sha }} --progress
+          git checkout FETCH_HEAD
+
+      - name: Configure pre-installed Java 25
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_25_X64" >> $GITHUB_ENV
+          echo "$JAVA_HOME_25_X64/bin" >> $GITHUB_PATH
+          java -version  # check that java is of the right version
+          javac -version
+
+      - name: Run tests
+        run: /bin/time make test-full verbose=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
           javac -version
 
       - name: Run tests
-        run: /bin/time make test-full verbose=true
+        run: /bin/time -v make test-full verbose=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
         run: |
           echo "JAVA_HOME=$JAVA_HOME_25_X64" >> $GITHUB_ENV
           echo "$JAVA_HOME_25_X64/bin" >> $GITHUB_PATH
-          java -version  # check that java is of the right version
+
+      - name: Check Java version
+        run: |
+          java -version
           javac -version
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !/src
 !/docs
 !/.gitignore
+!/.github
 !/LICENSE
 !/Makefile
 !/README.md

--- a/Makefile
+++ b/Makefile
@@ -199,9 +199,9 @@ test-execute: EXPERIMENTAL_JAVA_FLAGS := --enable-final-field-mutation=ALL-UNNAM
 # '$(EXPERIMENTAL_JAVA_FLAGS)' flag works only on Java 26+, so there is a check whether this flag is supported or not
 # tree-sitter for syntax highlighting goes crazy on next 4 lines, but they are containing correct syntax
 ifeq ($(IS_WIN),1)
-test-execute: __test-execute__java_args := $(shell $(call remove_suppress,$(call RUN_CMD, java $(EXPERIMENTAL_JAVA_FLAGS) -version > nul 2>&1 && echo $(EXPERIMENTAL_JAVA_FLAGS))))
+test-execute: __test-execute__java_args := $(shell $(call remove_suppress,$(call RUN_CMD, java $(EXPERIMENTAL_JAVA_FLAGS) -version > nul 2>&1 && echo $(EXPERIMENTAL_JAVA_FLAGS) || :)))
 else
-test-execute: __test-execute__java_args := $(shell sh -c "java $(EXPERIMENTAL_JAVA_FLAGS) -version > /dev/null 2>&1; [ $$? -eq 0 ] && echo '$(EXPERIMENTAL_JAVA_FLAGS)' || echo ''")
+test-execute: __test-execute__java_args := $(shell sh -c "set +e; java $(EXPERIMENTAL_JAVA_FLAGS) -version > /dev/null 2>&1 && echo '$(EXPERIMENTAL_JAVA_FLAGS)' || echo ''")
 endif
 test-execute: get-junit
 ifneq ($(silent), true)

--- a/Makefile
+++ b/Makefile
@@ -247,31 +247,32 @@ __get_junit_jar: __get_junit_jar__win__download_cmd__curl := curl -L -o $(LIBS_D
 
 # Method and command to execute on Windows to download the JUnit .jar file:
 #   Method   | Command
-#     ''     | bitsadmin
-#     1      | bitsadmin
-# bitsadmin  | bitsadmin
-#     2      | powershell
+#     ''     | powershell
+#     1      | powershell
 # powershell | powershell
+#     2      | bitsadmin
+# bitsadmin  | bitsadmin
 #     3      | curl
 #    curl    | curl
 # Note! Doesn't affect Unix-like environment. Only for windows
-__get_junit_jar__valid_methods := 1 bitsadmin 2 powershell 3 curl
+__get_junit_jar__valid_methods := 1 powershell 2 bitsadmin 3 curl
 
 define __get_junit_jar__valid_methods_msg
 Unknown method: $(FG_YELLOW)$(method)$(CA). Valid methods: $(subst $(SPACE),$(COMMA)$(SPACE),$(foreach m,$(__get_junit_jar__valid_methods),$(FG_GREEN)$(m)$(CA)))
 If other methods doesn't work, you can download the JUnit .jar file directly from the source via other methods:
 $(JUNIT_DOWNLOAD_URL)
 endef
+
 ifeq ($(method),)
-__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__bitsadmin)
+__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__powershell)
 else ifeq ($(method),1)
-__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__bitsadmin)
-else ifeq ($(method),bitsadmin)
-__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__bitsadmin)
-else ifeq ($(method),2)
 __get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__powershell)
 else ifeq ($(method),powershell)
 __get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__powershell)
+else ifeq ($(method),2)
+__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__bitsadmin)
+else ifeq ($(method),bitsadmin)
+__get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__bitsadmin)
 else ifeq ($(method),3)
 __get_junit_jar: __get_junit_jar__win__download_cmd := $(__get_junit_jar__win__download_cmd__curl)
 else ifeq ($(method),curl)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make test
 with optional parameters:
   - `silent=<boolean>`: suppresses the logging of each testing step
   - `verbose=<boolean>`: shows extra information what make does under the hood
-  - `method=<1|bitsadmin|2|powershell|3|curl>`: method for downloading dependency files on Windows (default: `bitsadmin`). If one method is slow or unavailable, try another one.
+  - `method=<1|powershell|2|bitsadmin|3|curl>`: method for downloading dependency files on Windows (default: `powershell`). If one method is slow or unavailable, try another one.
 
 or compile the source test code from the `./src/test/` directory manually, including the JUnit framework jar dependency, which can be obtained by running the:
 ```sh


### PR DESCRIPTION
The change to the Makefile was made to use powershell's `Invoke-WebRequest` by default to download files from internet on Windows, since CMD's `bitsadmin` works differently on different Windows systems (tested on: Windows 10 IoT LTSC 21H1, Windows 11 Home 25H2) (I have no idea why). Powershell should work more reliably.

If (for some reason) powershell refuses to download the file, use a different method (as defined in the README.md): `method=2` / `method=bitsadmin`, `method=3` / `method=curl` (if curl is installed). If all methods don't work, either download the dependencies manually (all URLs are in the Makefile), or switch to a normal OS (Unix-like).