### PR TITLE
build(Makefile): fix the ':' not recognized as a command in CMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-execute: EXPERIMENTAL_JAVA_FLAGS := --enable-final-field-mutation=ALL-UNNAM
 # '$(EXPERIMENTAL_JAVA_FLAGS)' flag works only on Java 26+, so there is a check whether this flag is supported or not
 # tree-sitter for syntax highlighting goes crazy on next 4 lines, but they are containing correct syntax
 ifeq ($(IS_WIN),1)
-test-execute: __test-execute__java_args := $(shell $(call remove_suppress,$(call RUN_CMD, java $(EXPERIMENTAL_JAVA_FLAGS) -version > nul 2>&1 && echo $(EXPERIMENTAL_JAVA_FLAGS) || :)))
+test-execute: __test-execute__java_args := $(shell $(call remove_suppress,$(call RUN_CMD, java $(EXPERIMENTAL_JAVA_FLAGS) -version > nul 2>&1 && echo $(EXPERIMENTAL_JAVA_FLAGS))))
 else
 test-execute: __test-execute__java_args := $(shell sh -c "set +e; java $(EXPERIMENTAL_JAVA_FLAGS) -version > /dev/null 2>&1 && echo '$(EXPERIMENTAL_JAVA_FLAGS)' || echo ''")
 endif

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DD := /
 endif
 
 # ========================
-# helper functions 
+# helper functions
 
 # Apply wildcard recursively in the given directory
 # Usage: $(call rwildcard,[directory where to look],[glob to apply])


### PR DESCRIPTION
There was an issue on Windows, specifically CMD when running the command, that the executable ':' is not recognized as valid, although I tested it and it behaved as expected. Again, massive Windows issue that it can't reliably execute the same commands.