### PR TITLE
fix(storage-pool): return defensive copies from getAll methods

### DIFF
--- a/src/onion/lifeproducts/rms/application/StoragePool.java
+++ b/src/onion/lifeproducts/rms/application/StoragePool.java
@@ -68,30 +68,39 @@ public class StoragePool {
 	}
 
 	/**
-	 * Returns all stored products.
+	 * Returns a copy of all stored products.
 	 *
-	 * @return list of all products
+	 * <p>The returned list is a defensive copy - callers may modify it freely
+	 * without affecting the internal pool.</p>
+	 *
+	 * @return copy of the product list
 	 */
 	public List<Product> getAllProducts() {
-		return this.productsPool;
+		return new ArrayList<>(this.productsPool);
 	}
 
 	/**
-	 * Returns all stored materials.
+	 * Returns a copy of all stored materials.
 	 *
-	 * @return list of all materials
+	 * <p>The returned list is a defensive copy - callers may modify it freely
+	 * without affecting the internal pool.</p>
+	 *
+	 * @return copy of the material list
 	 */
 	public List<Material> getAllMaterials() {
-		return this.materialsPool;
+		return new ArrayList<>(this.materialsPool);
 	}
 
 	/**
-	 * Returns all stored recycling guidance objects.
+	 * Returns a copy of all stored recycling guidance objects.
 	 *
-	 * @return list of all recycling guidance objects
+	 * <p>The returned list is a defensive copy - callers may modify it freely
+	 * without affecting the internal pool.</p>
+	 *
+	 * @return copy of the recycling guidance list
 	 */
 	public List<RecyclingGuidance> getAllRecyclingGuidance() {
-		return this.recyclingGuidancePool;
+		return new ArrayList<>(this.recyclingGuidancePool);
 	}
 
 	/**

--- a/src/test/StoragePoolTest.java
+++ b/src/test/StoragePoolTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class StoragePoolTest {
@@ -180,6 +182,53 @@ class StoragePoolTest {
 
         // Assert
         assertNull(found);
+    }
+
+    // --- defensive copies ---
+
+    @Test
+    @DisplayName("getAllProducts should return a copy - callers cannot modify the pool's internal data")
+    void shouldReturnDefensiveCopyFromGetAllProducts() {
+        // Arrange
+        Material mat = newMaterial("Plastic");
+        pool.addProduct(newProduct("Bottle", mat));
+
+        // Act - mutate the returned list
+        List<Product> returned = pool.getAllProducts();
+        returned.clear();
+
+        // Assert - internal pool is unchanged
+        assertEquals(1, pool.getAllProducts().size());
+    }
+
+    @Test
+    @DisplayName("getAllMaterials should return a copy - callers cannot modify the pool's internal data")
+    void shouldReturnDefensiveCopyFromGetAllMaterials() {
+        // Arrange
+        Material material = newMaterial("Steel");
+        pool.addMaterial(material);
+
+        // Act - mutate the returned list
+        List<Material> returned = pool.getAllMaterials();
+        returned.clear();
+
+        // Assert - internal pool is unchanged
+        assertEquals(1, pool.getAllMaterials().size());
+    }
+
+    @Test
+    @DisplayName("getAllRecyclingGuidance should return a copy - callers cannot modify the pool's internal data")
+    void shouldReturnDefensiveCopyFromGetAllRecyclingGuidance() {
+        // Arrange
+        RecyclingGuidance rg = new RecyclingGuidance("Rinse before recycling");
+        pool.addRecyclingGuidance(rg);
+
+        // Act - mutate the returned list
+        List<RecyclingGuidance> returned = pool.getAllRecyclingGuidance();
+        returned.clear();
+
+        // Assert - internal pool is unchanged
+        assertEquals(1, pool.getAllRecyclingGuidance().size());
     }
 
 }


### PR DESCRIPTION
- getAllProducts, getAllMaterials and getAllRecyclingGuidance now return new ArrayList copies instead of exposing the internal lists directly
- add 3 tests to StoragePoolTest verifying callers cannot modify the pool's internal data